### PR TITLE
Fix bug in split function

### DIFF
--- a/lib/split.lua
+++ b/lib/split.lua
@@ -121,9 +121,12 @@ local function split_ex(s, sep, plain, limit, after)
         end
     end
 
-    -- push remaining string
     if pos <= #s then
+        -- push remaining string
         arr[idx] = sub(s, pos)
+    elseif pos - 1 == #s then
+        -- push empty-string if last-match is at the end of string.
+        arr[idx] = ''
     end
 
     return arr

--- a/test/split_test.lua
+++ b/test/split_test.lua
@@ -11,8 +11,8 @@ local function test_split()
     assert.equal(split.split('foo', ''), {'f', 'o', 'o'})
 
     -- test that split a string with pattern '/'
-    assert.equal(split.split('foo/bar//baz/qux', '/'),
-                 {'foo', 'bar', '', 'baz', 'qux'})
+    assert.equal(split.split('foo/bar//baz/qux/', '/'),
+                 {'foo', 'bar', '', 'baz', 'qux', ''})
 
     -- test that split a string with pattern '/+'
     assert.equal(split.split('foo/bar//baz/qux', '/+'),


### PR DESCRIPTION
if the last match position is at the end of the string, an empty-string
must be added to the result array.